### PR TITLE
Test HealthCheck

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="Osmorc" url="file://$PROJECT_DIR$" />
   </component>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.146.30</version>
+        <version>0.146.51-SNAPSHOT</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>hello-world-plugin</artifactId>

--- a/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldActivator.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServlet;
 
+import org.killbill.billing.invoice.plugin.api.InvoiceFormatterFactory;
 import org.killbill.billing.invoice.plugin.api.InvoicePluginApi;
 import org.killbill.billing.osgi.api.Healthcheck;
 import org.killbill.billing.osgi.api.OSGIPluginProperties;
@@ -36,9 +37,12 @@ import org.killbill.billing.plugin.api.notification.PluginConfigurationEventHand
 import org.killbill.billing.plugin.core.config.PluginEnvironmentConfig;
 import org.killbill.billing.plugin.core.resources.jooby.PluginApp;
 import org.killbill.billing.plugin.core.resources.jooby.PluginAppBuilder;
+import org.killbill.commons.health.api.HealthCheckRegistry;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.ServiceTracker;
-import org.killbill.billing.invoice.plugin.api.InvoiceFormatterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HelloWorldActivator extends KillbillActivatorBase {
 
@@ -48,16 +52,26 @@ public class HelloWorldActivator extends KillbillActivatorBase {
     //
     public static final String PLUGIN_NAME = "hello-world-plugin";
 
+    private static final Logger logger = LoggerFactory.getLogger(HelloWorldActivator.class);
+
     private HelloWorldConfigurationHandler helloWorldConfigurationHandler;
     private OSGIKillbillEventDispatcher.OSGIKillbillEventHandler killbillEventHandler;
     private MetricsGeneratorExample metricsGenerator;
 
     private ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker;
 
+    private HealthCheckRegistry healthCheckRegistry;
+
     @Override
     public void start(final BundleContext context) throws Exception {
         super.start(context);
-
+        final ServiceReference<HealthCheckRegistry> reference = context.getServiceReference(HealthCheckRegistry.class);
+        if (reference != null) {
+            final HealthCheckRegistry healthCheckRegistry = context.getService(reference);
+            if (healthCheckRegistry != null) {
+                this.healthCheckRegistry = healthCheckRegistry;
+            }
+        }
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
 
         // Register an event listener for plugin configuration (optional)
@@ -72,7 +86,7 @@ public class HelloWorldActivator extends KillbillActivatorBase {
 
 
         // Register an event listener (optional)
-        killbillEventHandler = new HelloWorldListener(killbillAPI, invoiceFormatterTracker, configProperties.getProperties());
+        killbillEventHandler = new HelloWorldListener(killbillAPI, invoiceFormatterTracker, healthCheckRegistry, configProperties.getProperties());
 
         // As an example, this plugin registers a PaymentPluginApi (this could be
         // changed to any other plugin api)
@@ -99,6 +113,7 @@ public class HelloWorldActivator extends KillbillActivatorBase {
         registerServlet(context, httpServlet);
 
         registerHandlers();
+        //        HealthCheck aviateHealthCheck = hea
     }
 
     @Override

--- a/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldActivator.java
+++ b/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldActivator.java
@@ -60,18 +60,10 @@ public class HelloWorldActivator extends KillbillActivatorBase {
 
     private ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker;
 
-    private HealthCheckRegistry healthCheckRegistry;
 
     @Override
     public void start(final BundleContext context) throws Exception {
         super.start(context);
-        final ServiceReference<HealthCheckRegistry> reference = context.getServiceReference(HealthCheckRegistry.class);
-        if (reference != null) {
-            final HealthCheckRegistry healthCheckRegistry = context.getService(reference);
-            if (healthCheckRegistry != null) {
-                this.healthCheckRegistry = healthCheckRegistry;
-            }
-        }
         final String region = PluginEnvironmentConfig.getRegion(configProperties.getProperties());
 
         // Register an event listener for plugin configuration (optional)

--- a/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldListener.java
+++ b/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldListener.java
@@ -22,8 +22,8 @@ package org.killbill.billing.plugin.helloworld;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
 
-import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountApiException;
 import org.killbill.billing.invoice.api.Invoice;
@@ -36,6 +36,8 @@ import org.killbill.billing.osgi.libs.killbill.OSGIKillbillAPI;
 import org.killbill.billing.osgi.libs.killbill.OSGIKillbillEventDispatcher;
 import org.killbill.billing.plugin.api.PluginTenantContext;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.commons.health.api.HealthCheckRegistry;
+import org.killbill.commons.health.api.Result;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,9 +52,12 @@ public class HelloWorldListener implements OSGIKillbillEventDispatcher.OSGIKillb
 
     private final Properties configProperties;
 
-    public HelloWorldListener(final OSGIKillbillAPI killbillAPI, final ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker, Properties configProperties) {
+    private final HealthCheckRegistry healthCheckRegistry;
+
+    public HelloWorldListener(final OSGIKillbillAPI killbillAPI, final ServiceTracker<InvoiceFormatterFactory, InvoiceFormatterFactory> invoiceFormatterTracker, final HealthCheckRegistry healthCheckRegistry, final Properties configProperties) {
         this.osgiKillbillAPI = killbillAPI;
         this.invoiceFormatterTracker = invoiceFormatterTracker;
+        this.healthCheckRegistry = healthCheckRegistry;
         this.configProperties = configProperties;
     }
 
@@ -66,6 +71,7 @@ public class HelloWorldListener implements OSGIKillbillEventDispatcher.OSGIKillb
                     killbillEvent.getObjectType());
 
         final TenantContext context = new PluginTenantContext(killbillEvent.getAccountId(), killbillEvent.getTenantId());
+        //        HealthCheck aviateHealthCheck = hea
         switch (killbillEvent.getEventType()) {
             //
             // Handle ACCOUNT_CREATION and ACCOUNT_CHANGE only for demo purpose and just print the account
@@ -78,6 +84,14 @@ public class HelloWorldListener implements OSGIKillbillEventDispatcher.OSGIKillb
                 } catch (final AccountApiException e) {
                     logger.warn("Unable to find account", e);
                 }
+                final Set<String> names = healthCheckRegistry.getNames();
+                logger.info("names {}", names);
+                Result result = healthCheckRegistry.runHealthCheck("org.killbill.billing.server.healthchecks.KillbillHealthcheck");
+                logger.info("KB healthcheck result: {}", result.isHealthy());
+                result = healthCheckRegistry.runHealthCheck("org.killbill.billing.server.healthchecks.KillbillPluginsHealthcheck");
+                logger.info("Plugins healthcheck result: {}", result.isHealthy());
+                result = healthCheckRegistry.runHealthCheck("com.killbill.billing.plugin.aviate.AviateHealthCheck"); //This line fails
+                logger.info("Aviate healthcheck result: {}", result.isHealthy());
                 break;
             case INVOICE_CREATION:
 

--- a/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldListener.java
+++ b/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldListener.java
@@ -21,11 +21,17 @@ package org.killbill.billing.plugin.helloworld;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 
 import org.killbill.billing.account.api.Account;
 import org.killbill.billing.account.api.AccountApiException;
+import org.killbill.billing.entitlement.api.Subscription;
+import org.killbill.billing.entitlement.api.SubscriptionApiException;
+import org.killbill.billing.entitlement.api.SubscriptionEvent;
 import org.killbill.billing.invoice.api.Invoice;
 import org.killbill.billing.invoice.api.InvoiceItem;
 import org.killbill.billing.invoice.api.formatters.InvoiceFormatter;
@@ -90,9 +96,21 @@ public class HelloWorldListener implements OSGIKillbillEventDispatcher.OSGIKillb
                 logger.info("KB healthcheck result: {}", result.isHealthy());
                 result = healthCheckRegistry.runHealthCheck("org.killbill.billing.server.healthchecks.KillbillPluginsHealthcheck");
                 logger.info("Plugins healthcheck result: {}", result.isHealthy());
-                result = healthCheckRegistry.runHealthCheck("com.killbill.billing.plugin.aviate.AviateHealthCheck"); //This line fails
-                logger.info("Aviate healthcheck result: {}", result.isHealthy());
+                Map<String, Object> pluginHealthDetails = result.getDetails();
+                for(Entry<String, Object> entry: pluginHealthDetails.entrySet()) {
+                    String pluginKey = entry.getKey();
+                    Map<Object, Object> pluginDetails = (Map)entry.getValue();
+                    logger.info("Plugin {}, Details {}", entry.getKey(), entry.getValue());
+                }
                 break;
+            case SUBSCRIPTION_CREATION:
+                try {
+                    Subscription subscription = osgiKillbillAPI.getSubscriptionApi().getSubscriptionForEntitlementId(killbillEvent.getObjectId(), true, context);
+                    List<SubscriptionEvent> events = subscription.getSubscriptionEvents();
+                    logger.info("events:"+events);
+                } catch (SubscriptionApiException e) {
+                    throw new RuntimeException(e);
+                }
             case INVOICE_CREATION:
 
                 final Account account;


### PR DESCRIPTION
Test for https://github.com/killbill/killbill-platform/issues/145

**Edit:** Added some extra lines to display plugin health status.

I have the `hello-world`, `aviate` and `analytics` plugins installed. [This block](https://github.com/reshmabidikar/killbill-hello-world-java-plugin/blob/9f4c94a11b5490d557d5eac34246c6e3b7e9a82c/src/main/java/org/killbill/billing/plugin/helloworld/HelloWorldListener.java#L99:L104) prints the following:

```
2025-05-26T12:18:22,921+0000 lvl='INFO', log='HelloWorldListener', th='bus_ext_events-th', xff='', rId='', tok='789091d0-a7cc-45d6-b190-5e548e81f266', aRId='1260', tRId='1', Plugin hello-world-plugin, Details {}
2025-05-26T12:18:22,921+0000 lvl='INFO', log='HelloWorldListener', th='bus_ext_events-th', xff='', rId='', tok='789091d0-a7cc-45d6-b190-5e548e81f266', aRId='1260', tRId='1', Plugin aviate-plugin, Details {}
2025-05-26T12:18:22,921+0000 lvl='INFO', log='HelloWorldListener', th='bus_ext_events-th', xff='', rId='', tok='789091d0-a7cc-45d6-b190-5e548e81f266', aRId='1260', tRId='1', Plugin killbill-analytics, Details {AnalyticsListener=true, JobsScheduler=true}
```

So, we can conclude that the change in https://github.com/killbill/killbill-platform/pull/180 works as expected.